### PR TITLE
[DO NOT MERGE] Bleeding-edge Steam support

### DIFF
--- a/bms-helper.sh
+++ b/bms-helper.sh
@@ -3804,7 +3804,10 @@ install_game() {
         return 1
     fi
 
-    download_gog_installer
+    use_steam=$(message options "GOG" "Steam" "Which storefront did you use to purchase Falcon 4.0?")
+    if ! $use_steam; then
+        download_gog_installer
+    fi
     download_bms_installer
     # Abort if the download failed
     if [ "$?" -eq 1 ]; then
@@ -3893,11 +3896,19 @@ install_game() {
 
     # Run the Falcon 4.0 GoG installer
     debug_print continue "Installing Falcon 4.0. Please wait; this will take a moment..."
-    progress_update "Running Falcon 4.0 GoG installer..."
-    if [ -n "$selected_gog_installer" ]; then
-        wine "$selected_gog_installer" /VERYSILENT /NOICONS >>"$tmp_install_log" 2>&1
+    if ! $use_steam; then
+        progress_update "Running Falcon 4.0 GoG installer..."
+        if [ -n "$selected_gog_installer" ]; then
+            wine "$selected_gog_installer" /VERYSILENT /NOICONS >>"$tmp_install_log" 2>&1
+        else
+            wine "$SCRIPT_DIR/$gog_installer" /VERYSILENT /NOICONS >>"$tmp_install_log" 2>&1
+        fi
     else
-        wine "$SCRIPT_DIR/$gog_installer" /VERYSILENT /NOICONS >>"$tmp_install_log" 2>&1
+        progress_update "Installing Falcon 4.0 through Steam..."
+        message info "The script will now download and run Steam. Please log in, install Falcon 4.0, and launch it."
+        curl -o "SteamSetup.exe" "https://cdn.fastly.steamstatic.com/client/installer/SteamSetup.exe"
+        wine "SteamSetup.exe"
+        message info "Please install Falcon 4.0, run it once, and exit the game. The script will continue after closing this popup."
     fi
 
     # Run the Falcon BMS installer


### PR DESCRIPTION
I added very primitive Steam support by prompting the user whether they own Falcon 4.0 on GOG or Steam, and if they select Steam, the helper skips the GOG installer and then installs Steam, prompting the user to install F4.0 and run it once.

Currently there are two things that bug me a little but I unfortunately don't have the time nor bash knowledge to dig into them:
1. The helper has a "pausing" popup that the user has to not confirm until they've ran F4.0; would be better to find a way to wait until F4.0 is installed.
2. Steam is missing fonts - this can likely be fixed by adding the right font through winetricks, but I couldn't find which font Steam was using.

This PR is probably not production-ready, but it *is* something that is usable right now, albeit finicky. My hope was to provide a way that works and can be built upon.